### PR TITLE
Cast eventValue explicitly to Map<String, Object>

### DIFF
--- a/lib/almentor_analytics_module.dart
+++ b/lib/almentor_analytics_module.dart
@@ -79,7 +79,7 @@ class AlmentorAnalyticsModule {
       try {
         submitFirebaseAnalyticsEvent(
           eventName: eventName,
-          eventValue: isEventValueValidMap(eventValue) ? eventValue : null,
+          eventValue: isEventValueValidMap(eventValue) ? Map<String, Object>.from(eventValue) : null,
         );
       } catch (error, stackTrace) {
         AlmentorAnalyticsModule.onError!(error, stackTrace);


### PR DESCRIPTION
Please make sure you checked this Practices [Link](https://app.clickup.com/36211933/v/dc/12h36x-62355/12h36x-38755)
# Description

In an attempt to fix the crash below - it seems that all variants of this crash relate to the casting of the object eventValue when it's passed to submitFirebaseAnalyticsEvent and then to FirebaseAnalytics.instance.logEvent. 

Since logEvent expects an object of type Map<String, Object>, any other object that isn't explicitly cast will not work, even if it can be implicitly cast (ex. dynamic -> Object). 

This is the case in all variants of the crash:
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, Object?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, dynamic>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, dynamic>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, String?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, String?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, String?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, Object?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, Object?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, Object?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, Object?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, Object?>' is not a subtype of type 'Map<String, Object>?'
* io.flutter.plugins.firebase.crashlytics.FlutterError: type '_Map<String, String?>' is not a subtype of type 'Map<String, Object>?'

Since all crashes are objects that explicitly castable to Map<String, Object>, I've added the explicit cast in the submitFirebaseAnalyticsEvent check before eventually calling logEvent.

Fixes https://console.firebase.google.com/project/chrome-sphere-259409/crashlytics/app/android:com.almentor.app/issues/b77d66ed01645fbd608c3fb22442b083

## Performance Impact (Optional)
None expected

## Highlight (Optional)
* I've tested a lot of events, but we need to make sure that this did not impact any events. This should only impact Firebase events, so no need to check other event destinations.

# Are the following tests ready?

- [ ] Performance test
- [ ] E2E test

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I follow the practices we agreed on
- [ ] Tests cover business use cases
- [ ] New and existing unit tests pass locally with my changes
